### PR TITLE
SQL関係の処理の追加とlist-historyをフロントに送る処理の追加

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -81,6 +81,23 @@ server.mount_proc '/get-ingredient' do |req, res|
   res['Content-Type'] = 'application/json'
 end
 
+server.mount_proc '/get-list' do |req, res|
+  data = client.get_list_result
+
+  res.body = data
+  res['Content-Type'] = 'application/json'
+end
+
+server.mount_proc 'get-list-test' do |req, res|
+  data = [
+    {"list_id"=>1, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
+    {"list_id"=>2, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
+    {"list_id"=>3, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
+    {"list_id"=>4, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
+    {"list_id"=>5, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
+  ]
+end
+
 trap('INT'){server.shutdown}
 
 server.start

--- a/server.rb
+++ b/server.rb
@@ -88,14 +88,17 @@ server.mount_proc '/get-list' do |req, res|
   res['Content-Type'] = 'application/json'
 end
 
-server.mount_proc 'get-list-test' do |req, res|
+server.mount_proc '/get-list-test' do |req, res|
   data = [
-    {"list_id"=>1, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
-    {"list_id"=>2, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
-    {"list_id"=>3, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
-    {"list_id"=>4, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
-    {"list_id"=>5, "recipe_names"=>["寿司", "ピザ"], "date"=>2023-11-29 20:54:17 +0900}
+    {"list_id"=>1, "recipe_names"=>["寿司", "ピザ"], "date"=>Time.local(2023, 12, 1)},
+    {"list_id"=>2, "recipe_names"=>["寿司", "ピザ", "ラーメン"], "date"=>Time.local(2023, 12, 1)},
+    {"list_id"=>3, "recipe_names"=>["寿司", "ピザ", "親子丼", "味噌汁", "カルボナーラ"], "date"=>Time.local(2023, 12, 1)},
+    {"list_id"=>4, "recipe_names"=>["中華スープ", "麻婆豆腐"], "date"=>Time.local(2023, 12, 1)},
+    {"list_id"=>5, "recipe_names"=>["ボンゴレロッソ"], "date"=>Time.local(2023, 12, 1)},
   ]
+
+  res.body = data.to_json
+  res['Content-Type'] = 'application/json'
 end
 
 trap('INT'){server.shutdown}

--- a/sql_control.rb
+++ b/sql_control.rb
@@ -5,7 +5,8 @@ require 'mysql2'
 
 class SQLControl
   def initialize
-    @client = Mysql2::Client.new(host: "localhost", username: "K5", password: "G465j7R7^Nbgd$", database: "shopping_list")
+    # ここのusername と passwordをそれぞれ書き換えて運用する
+    @client = Mysql2::Client.new(host: "localhost", username: "", password: "", database: "shopping_list")
   end
 
   def get_search_result(word="", id="")
@@ -14,12 +15,46 @@ class SQLControl
       FROM
         users AS u
         INNER JOIN recipes AS r ON u.id = r.user_id
-        
-      LIMIT 10
+        WHERE r.name LIKE "%#{word}%"
+      LIMIT 10;
     }
     result = @client.query(select_statement)
 
     result.to_a.to_json
+  end
+
+  def get_recipe_ingredient(recipes)
+    select_statement %{
+      SELECT i.id AS ingredient_id, i.name AS ingredient_name, SUM(ia.amount) AS ingredient_amount
+      FROM
+        recipes AS r
+        INNER JOIN ingredients_amount AS ia ON r.id = ia.recipe_id
+        INNER JOIN ingredients AS i ON ia.ingredient_id = i.id
+        WHERE r.id = "#{recipes[0]}"
+        GROUP BY i.id, i.name;
+    }
+
+    result = @client.query(select_statement)
+
+    result.to_a.to_json
+  end
+
+  def get_list_result(uid="")
+    select_statement = %{
+      SELECT l.id AS list_id, r.name AS recipe_name, l.created_at AS date
+        FROM
+          shopping_lists AS l
+          INNER JOIN list_recipes AS lr ON l.id = lr.shopping_list_id
+          INNER JOIN recipes AS r ON lr.recipe_id = r.id
+          GROUP BY l.id, r.name, l.created_at
+          ORDER BY l.created_at DESC
+          LIMIT 120;
+    }
+
+    sql_result = @client.query(select_statement).to_a
+    result = create_list_history(sql_result).to_json
+
+    result
   end
 
   def get_user_data(mail, password)
@@ -28,5 +63,24 @@ class SQLControl
     result = @client.query(select_statement)
 
     result.to_a.to_json
+  end
+
+  def create_list_history(arr)
+    ids = []
+    res = []
+
+    arr.each do |ele|
+      if ids.include?(ele["list_id"])
+        index = ids.index(ele["list_id"])
+        res[index]["recipe_names"].push(ele["recipe_name"])
+      else
+        ids.push(ele["list_id"])
+        if ids.length > 10
+          break
+        end
+        res.push({"list_id" => ele["list_id"], "recipe_names" => [ele["recipe_name"]], "date" => ele["date"]})
+      end
+    end
+    res
   end
 end


### PR DESCRIPTION
# /get-list と テスト用の /get-list-testを追加した

画面8で使用する過去に作成した買い物リストを取得するためのAPIを実装しました。
/get-listの方は本実装バージョンだが現状データベースに登録されていデータが少ないため。データ量が増えた時のためのサンプルとしてget-list-testも実装した。
この二つは同じ形式のデータを返すはずです。